### PR TITLE
Break aot_create_comp_data into small functions

### DIFF
--- a/core/iwasm/compilation/aot.c
+++ b/core/iwasm/compilation/aot.c
@@ -487,57 +487,68 @@ calculate_struct_field_sizes_offsets(AOTCompData *comp_data, bool is_target_x86,
 }
 #endif
 
-AOTCompData *
-aot_create_comp_data(WASMModule *module, const char *target_arch,
-                     bool gc_enabled)
+/**
+ * Checks if target architecture is 64-bit based on target_arch string.
+ *
+ * @param target_arch The target architecture string (e.g. "x86_64", "aarch64")
+ * @return true if target is 64-bit architecture, false otherwise
+ *
+ * If target_arch is NULL, detection is based on UINTPTR_MAX.
+ * Otherwise looks for "64" in target_arch string.
+ */
+static bool
+arch_is_64bit(const char *target_arch)
 {
-    AOTCompData *comp_data;
-    uint32 import_global_data_size_64bit = 0, global_data_size_64bit = 0, i, j;
-    uint32 import_global_data_size_32bit = 0, global_data_size_32bit = 0;
-    uint64 size;
-    bool is_64bit_target = false;
-#if WASM_ENABLE_GC != 0
-    bool is_target_x86 = false;
+    if (!target_arch) {
+#if UINTPTR_MAX == UINT64_MAX
+        return true;
+#else
+        return false;
 #endif
+    }
+    /* All 64bit targets contains "64" string in their target name */
+    return strstr(target_arch, "64") != NULL;
+}
 
-#if WASM_ENABLE_GC != 0
+/**
+ * Checks if target architecture is x86/x64 based on target_arch string.
+ *
+ * @param target_arch The target architecture string (e.g. "x86_64", "i386")
+ * @return true if target is x86/x64 architecture, false otherwise
+ *
+ * If target_arch is NULL, detection is based on build-time definitions.
+ * Otherwise checks for x86_64 or i386 in target_arch string.
+ */
+static bool
+arch_is_x86(const char *target_arch)
+{
     if (!target_arch) {
 #if defined(BUILD_TARGET_X86_64) || defined(BUILD_TARGET_AMD_64) \
     || defined(BUILD_TARGET_X86_32)
-        is_target_x86 = true;
+        return true;
+#else
+        return false;
 #endif
     }
-    else {
-        if (!strncmp(target_arch, "x86_64", 6)
-            || !strncmp(target_arch, "i386", 4))
-            is_target_x86 = true;
-    }
-#endif
+    return !strncmp(target_arch, "x86_64", 6)
+           || !strncmp(target_arch, "i386", 4);
+}
 
-    if (!target_arch) {
-#if UINTPTR_MAX == UINT64_MAX
-        is_64bit_target = true;
-#endif
-    }
-    else {
-        /* All 64bit targets contains "64" string in their target name */
-        if (strstr(target_arch, "64") != NULL) {
-            is_64bit_target = true;
-        }
-    }
-
-    /* Allocate memory */
-    if (!(comp_data = wasm_runtime_malloc(sizeof(AOTCompData)))) {
-        aot_set_last_error("create compile data failed.\n");
-        return NULL;
-    }
-
-    memset(comp_data, 0, sizeof(AOTCompData));
+/**
+ * Initialize memory information in AOT compilation data from WASM module.
+ *
+ * @param comp_data the AOT compilation data structure to initialize
+ * @param module the source WASM module containing memory information
+ * @return true if initialization succeeded, false otherwise
+ */
+static bool
+aot_init_memories(AOTCompData *comp_data, WASMModule *module)
+{
+    uint32 i, j;
+    uint64 size;
 
     comp_data->memory_count =
         module->import_memory_count + module->memory_count;
-
-    /* TODO: create import memories */
 
     /* Allocate memory for memory array, reserve one AOTMemory space at least */
     if (!comp_data->memory_count)
@@ -547,7 +558,7 @@ aot_create_comp_data(WASMModule *module, const char *target_arch,
     if (size >= UINT32_MAX
         || !(comp_data->memories = wasm_runtime_malloc((uint32)size))) {
         aot_set_last_error("create memories array failed.\n");
-        goto fail;
+        return false;
     }
     memset(comp_data->memories, 0, size);
 
@@ -579,22 +590,30 @@ aot_create_comp_data(WASMModule *module, const char *target_arch,
         }
     }
 
-    /* Create memory data segments */
-    comp_data->mem_init_data_count = module->data_seg_count;
-    if (comp_data->mem_init_data_count > 0
-        && !(comp_data->mem_init_data_list =
-                 aot_create_mem_init_data_list(module)))
-        goto fail;
+    return true;
+}
 
-    /* Create tables */
+/**
+ * Initialize table information in AOT compilation data from WASM module.
+ *
+ * @param comp_data the AOT compilation data structure to initialize
+ * @param module the source WASM module containing table information
+ * @return true if initialization succeeded, false otherwise
+ */
+static bool
+aot_init_tables(AOTCompData *comp_data, WASMModule *module)
+{
+    uint32 i, j;
+    uint64 size;
+
     comp_data->table_count = module->import_table_count + module->table_count;
 
     if (comp_data->table_count > 0) {
         size = sizeof(AOTTable) * (uint64)comp_data->table_count;
         if (size >= UINT32_MAX
             || !(comp_data->tables = wasm_runtime_malloc((uint32)size))) {
-            aot_set_last_error("create memories array failed.\n");
-            goto fail;
+            aot_set_last_error("create tables array failed.\n");
+            return false;
         }
         memset(comp_data->tables, 0, size);
         for (i = 0; i < comp_data->table_count; i++) {
@@ -638,64 +657,150 @@ aot_create_comp_data(WASMModule *module, const char *target_arch,
         }
     }
 
-    /* Create table data segments */
+    return true;
+}
+
+/**
+ * Initialize memory segment information in AOT compilation data.
+ *
+ * @param comp_data the AOT compilation data structure to initialize
+ * @param module the source WASM module containing memory segments
+ * @return true if initialization succeeded, false otherwise
+ */
+static bool
+aot_init_memory_segments(AOTCompData *comp_data, WASMModule *module)
+{
+    comp_data->mem_init_data_count = module->data_seg_count;
+    if (comp_data->mem_init_data_count > 0
+        && !(comp_data->mem_init_data_list =
+                 aot_create_mem_init_data_list(module))) {
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Initialize table segment information in AOT compilation data.
+ *
+ * @param comp_data the AOT compilation data structure to initialize
+ * @param module the source WASM module containing table segments
+ * @return true if initialization succeeded, false otherwise
+ */
+static bool
+aot_init_table_segments(AOTCompData *comp_data, WASMModule *module)
+{
     comp_data->table_init_data_count = module->table_seg_count;
     if (comp_data->table_init_data_count > 0
         && !(comp_data->table_init_data_list =
-                 aot_create_table_init_data_list(module)))
-        goto fail;
+                 aot_create_table_init_data_list(module))) {
+        return false;
+    }
+    return true;
+}
 
-    /* Create import globals */
+/**
+ * Initialize global variable information in AOT compilation data.
+ *
+ * @param comp_data the AOT compilation data structure to initialize
+ * @param module the source WASM module containing global information
+ * @param gc_enabled whether garbage collection is enabled
+ * @param import_global_data_size_64bit [out] size of imported global data for
+ * 64-bit
+ * @param import_global_data_size_32bit [out] size of imported global data for
+ * 32-bit
+ * @param global_data_size_64bit [out] size of global data for 64-bit
+ * @param global_data_size_32bit [out] size of global data for 32-bit
+ * @return true if initialization succeeded, false otherwise
+ */
+static bool
+aot_init_globals(AOTCompData *comp_data, WASMModule *module, bool gc_enabled,
+                 uint32 *import_global_data_size_64bit,
+                 uint32 *import_global_data_size_32bit,
+                 uint32 *global_data_size_64bit, uint32 *global_data_size_32bit)
+{
     comp_data->import_global_count = module->import_global_count;
     if (comp_data->import_global_count > 0
         && !(comp_data->import_globals = aot_create_import_globals(
-                 module, gc_enabled, &import_global_data_size_64bit,
-                 &import_global_data_size_32bit)))
-        goto fail;
+                 module, gc_enabled, import_global_data_size_64bit,
+                 import_global_data_size_32bit))) {
+        return false;
+    }
 
-    /* Create globals */
     comp_data->global_count = module->global_count;
     if (comp_data->global_count
         && !(comp_data->globals = aot_create_globals(
-                 module, gc_enabled, import_global_data_size_64bit,
-                 import_global_data_size_32bit, &global_data_size_64bit,
-                 &global_data_size_32bit)))
-        goto fail;
+                 module, gc_enabled, *import_global_data_size_64bit,
+                 *import_global_data_size_32bit, global_data_size_64bit,
+                 global_data_size_32bit))) {
+        return false;
+    }
 
     comp_data->global_data_size_64bit =
-        import_global_data_size_64bit + global_data_size_64bit;
+        *import_global_data_size_64bit + *global_data_size_64bit;
     comp_data->global_data_size_32bit =
-        import_global_data_size_32bit + global_data_size_32bit;
+        *import_global_data_size_32bit + *global_data_size_32bit;
 
-    /* Create types, they are checked by wasm loader */
+    return true;
+}
+
+/**
+ * Initialize type information in AOT compilation data.
+ *
+ * @param comp_data the AOT compilation data structure to initialize
+ * @param module the source WASM module containing type information
+ * @param is_target_x86 whether the target architecture is x86
+ * @param gc_enabled whether garbage collection is enabled
+ * @return true if initialization succeeded, false otherwise
+ */
+static bool
+aot_init_types(AOTCompData *comp_data, WASMModule *module, bool is_target_x86,
+               bool gc_enabled)
+{
     comp_data->type_count = module->type_count;
     comp_data->types = module->types;
 #if WASM_ENABLE_GC != 0
-    /* Calculate the field sizes and field offsets for 64-bit and 32-bit
-       targets since they may vary in 32-bit target and 64-bit target */
     calculate_struct_field_sizes_offsets(comp_data, is_target_x86, gc_enabled);
 #endif
+    return true;
+}
 
-    /* Create import functions */
+/**
+ * Initialize function information in AOT compilation data.
+ *
+ * @param comp_data the AOT compilation data structure to initialize
+ * @param module the source WASM module containing function information
+ * @param is_64bit_target whether the target architecture is 64-bit
+ * @return true if initialization succeeded, false otherwise
+ */
+static bool
+aot_init_functions(AOTCompData *comp_data, WASMModule *module,
+                   bool is_64bit_target)
+{
     comp_data->import_func_count = module->import_function_count;
     if (comp_data->import_func_count
-        && !(comp_data->import_funcs = aot_create_import_funcs(module)))
-        goto fail;
+        && !(comp_data->import_funcs = aot_create_import_funcs(module))) {
+        return false;
+    }
 
-    /* Create functions */
     comp_data->func_count = module->function_count;
     if (comp_data->func_count
         && !(comp_data->funcs =
-                 aot_create_funcs(module, is_64bit_target ? 8 : 4)))
-        goto fail;
+                 aot_create_funcs(module, is_64bit_target ? 8 : 4))) {
+        return false;
+    }
 
-#if WASM_ENABLE_CUSTOM_NAME_SECTION != 0
-    /* Create custom name section */
-    comp_data->name_section_buf = module->name_section_buf;
-    comp_data->name_section_buf_end = module->name_section_buf_end;
-#endif
+    return true;
+}
 
-    /* Create aux data/heap/stack information */
+/**
+ * Initialize auxiliary data in AOT compilation data.
+ *
+ * @param comp_data the AOT compilation data structure to initialize
+ * @param module the source WASM module containing auxiliary data
+ */
+static void
+aot_init_aux_data(AOTCompData *comp_data, WASMModule *module)
+{
     comp_data->aux_data_end_global_index = module->aux_data_end_global_index;
     comp_data->aux_data_end = module->aux_data_end;
     comp_data->aux_heap_base_global_index = module->aux_heap_base_global_index;
@@ -714,6 +819,43 @@ aot_create_comp_data(WASMModule *module, const char *target_arch,
     comp_data->string_literal_ptrs_wp = module->string_literal_ptrs;
     comp_data->string_literal_lengths_wp = module->string_literal_lengths;
 #endif
+}
+
+AOTCompData *
+aot_create_comp_data(WASMModule *module, const char *target_arch,
+                     bool gc_enabled)
+{
+    AOTCompData *comp_data;
+    uint32 import_global_data_size_64bit = 0, global_data_size_64bit = 0;
+    uint32 import_global_data_size_32bit = 0, global_data_size_32bit = 0;
+    bool is_64bit_target = arch_is_64bit(target_arch);
+    bool is_target_x86 = arch_is_x86(target_arch);
+
+    if (!(comp_data = wasm_runtime_malloc(sizeof(AOTCompData)))) {
+        aot_set_last_error("create compile data failed.\n");
+        return NULL;
+    }
+    memset(comp_data, 0, sizeof(AOTCompData));
+
+    if (!aot_init_memories(comp_data, module)
+        || !aot_init_memory_segments(comp_data, module)
+        || !aot_init_tables(comp_data, module)
+        || !aot_init_table_segments(comp_data, module)
+        || !aot_init_globals(comp_data, module, gc_enabled,
+                             &import_global_data_size_64bit,
+                             &import_global_data_size_32bit,
+                             &global_data_size_64bit, &global_data_size_32bit)
+        || !aot_init_types(comp_data, module, is_target_x86, gc_enabled)
+        || !aot_init_functions(comp_data, module, is_64bit_target)) {
+        goto fail;
+    }
+
+#if WASM_ENABLE_CUSTOM_NAME_SECTION != 0
+    comp_data->name_section_buf = module->name_section_buf;
+    comp_data->name_section_buf_end = module->name_section_buf_end;
+#endif
+
+    aot_init_aux_data(comp_data, module);
 
     comp_data->wasm_module = module;
 


### PR DESCRIPTION
## Summary
- Refactored `aot_create_comp_data` into smaller, more specialized functions to improve code readability and maintainability.
- Added helper functions to separately handle the initialization of memories, memory segments, tables, table segments, globals, types, and functions.
- Each function now has a clear responsibility and returns a boolean indicating success or failure.
- The main `aot_create_comp_data` function now logically groups these initialization steps and handles errors more gracefully.

## Impact
- No functional changes - the behavior of the `aot_create_comp_data` function remains the same.
- The code is now more modular, making it easier to understand, test, and maintain.
- Error handling is more consistent, with each step clearly indicating whether it succeeded or failed.
