### PR TITLE
core: Always set gc_heap_size_default to support initialize multiple …

### DIFF
--- a/core/iwasm/common/wasm_runtime_common.c
+++ b/core/iwasm/common/wasm_runtime_common.c
@@ -801,6 +801,14 @@ wasm_runtime_full_init(RuntimeInitArgs *init_args)
         runtime_ref_count++;
     }
 
+    /* FIXME: Implement real multi-instance support instead of
+     * using global variables here
+     */
+
+#if WASM_ENABLE_GC != 0
+    gc_heap_size_default = init_args->gc_heap_size;
+#endif
+
 #if defined(OS_THREAD_MUTEX_INITIALIZER)
     os_mutex_unlock(&runtime_lock);
 #endif


### PR DESCRIPTION
## Summary
- Updated the `wasm_runtime_full_init` function to always set `gc_heap_size_default` during initialization
- This ensures that the garbage collection heap size is correctly configured even when the runtime is initialized multiple times

## Impact
- Enhances the robustness of the runtime initialization process for multi-instance environments
- No impact on single-instance use cases, but prepares the codebase for better multi-instance support in the future
